### PR TITLE
Allow users to update own location

### DIFF
--- a/app/endpoints/location.js
+++ b/app/endpoints/location.js
@@ -32,7 +32,7 @@ module.exports = function (app) {
     ],
     preRead: mustbe.authorized('view all locations', okAuth, noAuth),
     preUpdate: [
-      mustbe.authorized('update own item or admin games', okAuth, noAuth)
+      mustbe.authorized('update own location or admin games', okAuth, noAuth)
     ],
     preDelete: mustbe.authorized('admin games', okAuth, noAuth)
   });

--- a/app/endpoints/location.js
+++ b/app/endpoints/location.js
@@ -31,7 +31,9 @@ module.exports = function (app) {
       }
     ],
     preRead: mustbe.authorized('view all locations', okAuth, noAuth),
-    preUpdate: mustbe.authorized('admin games', okAuth, noAuth),
+    preUpdate: [
+      mustbe.authorized('update own item or admin games', okAuth, noAuth)
+    ],
     preDelete: mustbe.authorized('admin games', okAuth, noAuth)
   });
 };

--- a/config/security.js
+++ b/config/security.js
@@ -66,10 +66,19 @@ module.exports = function(app, config) {
       rh.notAuthorized(function(req, res, next){
         res.status(401);
       });
+
+      rh.parameterMaps(function(params){
+        params.map('update own item or admin games', function(req) {
+          // store user so we may later check against it
+          // @todo load record from database so we can ensure that noone takes over other users records
+          return {
+            owner: req.body.user
+          };
+        });
+      });
     });
 
     config.userIdentity(function(id) {
-
       // determine if this user is authenticated or not
       id.isAuthenticated(function(user, cb){
         // note that the "user" in this case, is the user
@@ -85,6 +94,9 @@ module.exports = function(app, config) {
       });
       activities.can("view all locations", function(identity, params, cb) {
         cb(null, identity.user.isGameMaster());
+      });
+      activities.can("update own item or admin games", function(identity, params, cb) {
+        cb(null, identity.user.isAdmin() || identity.user._id == params.owner);
       });
       activities.can("admin games", function(identity, params, cb) {
         cb(null, identity.user.isAdmin());


### PR DESCRIPTION
Adds a new activity called `update own location or admin games` used to decide if a user may edit a given record.

I think this should be all that we need to get the client side sorted but still need to do some more testing.

We'll probably want to revisit this as soon as we have game objects since they will most likely be an additional concern that the client needs to take into account.
