### PR TITLE
added geojson support to backend

### DIFF
--- a/app/endpoints/playfield.js
+++ b/app/endpoints/playfield.js
@@ -1,0 +1,40 @@
+var express = require('express'),
+  cors = require('cors'),
+  passport = require('passport'),
+  mongoose = require('mongoose'),
+  restify = require('express-restify-mongoose'),
+  mustbe = require("mustbe").routeHelpers(),
+  router = express.Router(),
+  Playfield = mongoose.model('Playfield');
+
+module.exports = function (app) {
+  app.use(cors());
+  app.use(passport.authenticate('jwt', { session: false }));
+  app.use('/', router);
+
+  okAuth = function(req, res, next) {
+    next();
+  };
+  noAuth = function(req, res, next) {
+    res.send(401, 'Authorization failed');
+  };
+
+  restify.serve(router, Playfield, {
+    version: '',
+    prefix: '',
+    lowercase: true,
+    preCreate: [
+      mustbe.authorized('admin games', okAuth, noAuth),
+      function(req, res, next) {
+        req.body.user = req.user;
+        next();
+      }
+    ],
+    preRead: mustbe.authorized('report location', okAuth, noAuth),
+    preUpdate: [
+      mustbe.authorized('admin games', okAuth, noAuth)
+    ],
+    preDelete: mustbe.authorized('admin games', okAuth, noAuth)
+  });
+};
+

--- a/app/models/playfield.js
+++ b/app/models/playfield.js
@@ -1,0 +1,11 @@
+// Playfield model
+
+var GeoJSON = require('mongoose-geojson-schema');
+var mongoose = require('mongoose'),
+  Schema = mongoose.Schema;
+
+var PlayfieldSchema = new Schema({
+  geoFeature:GeoJSON.Feature
+});
+
+mongoose.model('Playfield', PlayfieldSchema);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "passport": "^0.3.2",
     "passport-github2": "^0.1.9",
     "passport-jwt": "^1.2.1",
-    "serve-favicon": "^2.3.0"
+    "serve-favicon": "^2.3.0",
+    "mongoose-geojson-schema": "0.0.2"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
# Summary

I added a GeoJSON support to the Backend, to implement the Playfield in the future
## Implementation

Implementet Support for https://www.npmjs.com/package/mongoose-geojson-schema
## Acces

I set the Acces to the Playfield as followed:
- Create/Edit/Delete: Admin
- See: LoggedIn Player
